### PR TITLE
Update user documentation .bashrc adds

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ To start using the uct-cbio/16S-rDNA-dada2-pipeline, follow the steps below:
 1. [Install Nextflow](#install-nextflow)
 2. [Install the pipeline](#install-the-pipeline)
 
-## 1) Install NextFlow
+## 1) Install NextFlow (UCT users see below instead)
 Nextflow runs on most POSIX systems (Linux, Mac OSX etc). It can be installed by running the following commands:
 
 ```bash
@@ -29,6 +29,7 @@ curl -fsSL get.nextflow.io | bash
 #Add the following to ~/.bashrc:
 JAVA_HOME=/opt/exp_soft/java/jdk1.8.0_31/
 JAVA_CMD=/opt/exp_soft/java/jdk1.8.0_31/bin/java
+export PATH=$PATH:/opt/exp_soft/cbio/nextflow
 
 #Do not run nextflow from the headnode, it requires substantial memory to run java. Please therefore first start an interactive job as follows: 
 qsub -I -q UCTlong -l nodes=1:series600:ppn=1 -d `pwd`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,9 +8,10 @@ It is recommended to limit the Nextflow Java virtual machines memory. We recomme
 ```bash
 NXF_OPTS='-Xms1g -Xmx4g'
 ```
-For University of Cape Town users who will be running Nextflow on UCT's HPC (hex), you also need to include the following two lines in your `~/.bashrc`:
+For University of Cape Town users who will be running Nextflow on UCT's HPC (hex), you also need to include the following lines in your `~/.bashrc`:
 
 ```bash
+export JAVA_HOME=/opt/exp_soft/java/jdk1.8.0_31/
 JAVA_CMD=/opt/exp_soft/java/jdk1.8.0_31/bin/java
 export PATH=$PATH:/opt/exp_soft/cbio/nextflow
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ It is recommended to limit the Nextflow Java virtual machines memory. We recomme
 ```bash
 NXF_OPTS='-Xms1g -Xmx4g'
 ```
-For University of Cape Town users who will be running Nextflow on UCT's HPC (hex), you need to include the following two lines in your `~/.bachrc`:
+For University of Cape Town users who will be running Nextflow on UCT's HPC (hex), you also need to include the following two lines in your `~/.bashrc`:
 
 JAVA_CMD=/opt/exp_soft/java/jdk1.8.0_31/bin/java
 export PATH=$PATH:/opt/exp_soft/cbio/nextflow

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,8 +10,10 @@ NXF_OPTS='-Xms1g -Xmx4g'
 ```
 For University of Cape Town users who will be running Nextflow on UCT's HPC (hex), you also need to include the following two lines in your `~/.bashrc`:
 
+```bash
 JAVA_CMD=/opt/exp_soft/java/jdk1.8.0_31/bin/java
 export PATH=$PATH:/opt/exp_soft/cbio/nextflow
+```
 
 ## Running the pipeline
 The typical command for running the pipeline is as follows:


### PR DESCRIPTION
For UCT hex users add certain lines to ~/.bashrc. This commit makes instructions uniform between the 'installation' and 'usage' pages